### PR TITLE
公欠届再提出処理API

### DIFF
--- a/go/src/main/api/ResubmitDocument.go
+++ b/go/src/main/api/ResubmitDocument.go
@@ -59,6 +59,9 @@ func ResubmitDocument(c *gin.Context) {
 		//再提出する書類と提出者が一致しない、または再提出する書類のステータスが-1でない場合
 		c.JSON(http.StatusBadRequest, gin.H{"document": "DOCUMENT ERROR"})
 		return
+	} else if request.StudentComment == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"document": "COMMENT ERROR"})
+		return
 	}
 
 	//更新用構造体

--- a/go/src/main/api/ResubmitDocument.go
+++ b/go/src/main/api/ResubmitDocument.go
@@ -41,7 +41,6 @@ import (
 func ResubmitDocument(c *gin.Context) {
 	request := model.ResubmitDocumentRequest{}
 	responseMessage := "RESUBMIT SUCCESS"
-	testnum := 0
 
 	// var test int
 
@@ -61,7 +60,7 @@ func ResubmitDocument(c *gin.Context) {
 		EndTime:        request.EndTime,
 		EndFlame:       request.EndFlame,
 		Location:       request.Location,
-		Status:         &testnum,
+		Status:         1,
 		ReadFlag:       false,
 		StudentComment: request.StudentComment,
 		TeacherComment: request.TeacherComment,

--- a/go/src/main/api/ResubmitDocument.go
+++ b/go/src/main/api/ResubmitDocument.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"net/http"
+
+	"main/infra"
+	"main/model"
+
+	"github.com/gin-gonic/gin"
+)
+
+// type ResubmitDocumentRequest struct {
+// 	DocumentID     int       `json:"document_id"`
+// 	UserID         int       `json:"user_id"`
+// 	RequestAt      time.Time `json:"request_at"`
+// 	StartTime      time.Time `json:"start_time"`
+// 	StartFlame     int       `json:"start_flame"`
+// 	EndTime        time.Time `json:"end_time"`
+// 	EndFlame       int       `json:"end_flame"`
+// 	Location       string    `json:"location"`
+// 	StudentComment string    `json:"student_comment"`
+// 	TeacherComment string    `json:"teacher_comment"`
+// 	DivisionID     int       `json:"division_id"`
+// }
+// type ResubmitDocument struct {
+// 	DocumentID     int       `json:"document_id"`     //書類ID
+// 	UserID         int       `json:"user_id"`         //ユーザID
+// 	RequestAt      time.Time `json:"request_at"`      // 申請日
+// 	StartTime      time.Time `json:"start_time"`      // 欠席開始日
+// 	StartFlame     int       `json:"start_flame"`     //開始時限
+// 	EndTime        time.Time `json:"end_time"`        // 欠席終了日
+// 	EndFlame       int       `json:"end_flame"`       //終了時限
+// 	Location       string    `json:"location"`        // 場所
+// 	Status         int       `json:"status"`          //ステータス
+// 	ReadFlag       int       `json:"read_flag"`       //既読フラグ
+// 	StudentComment string    `json:"student_comment"` // 学生コメント
+// 	TeacherComment string    `json:"teacher_comment"` //教員コメント
+// 	DivisionID     int       `json:"division_id"`     //区分ID
+// }
+
+func ResubmitDocument(c *gin.Context) {
+	request := model.ResubmitDocumentRequest{}
+	responseMessage := "RESUBMIT SUCCESS"
+	testnum := 0
+
+	// var test int
+
+	if err := c.ShouldBindJSON(&request); err != nil {
+		// エラーな場合、ステータス400と、エラー情報を返す
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	//更新用構造体
+	oa := model.ResubmitDocument{
+		DocumentID:     request.DocumentID,
+		UserID:         request.UserID,
+		RequestAt:      request.RequestAt,
+		StartTime:      request.StartTime,
+		StartFlame:     request.StartFlame,
+		EndTime:        request.EndTime,
+		EndFlame:       request.EndFlame,
+		Location:       request.Location,
+		Status:         &testnum,
+		ReadFlag:       false,
+		StudentComment: request.StudentComment,
+		TeacherComment: request.TeacherComment,
+		DivisionID:     request.DivisionID,
+	}
+
+	//DB接続
+	db := infra.DBInitGorm()
+
+	//更新を実行
+	//db.Table("oa").Where("document_id = ?", request.DocumentID).Updates(&oa)
+	if err := db.Table("oa").Where("document_id = ?", request.DocumentID).Updates(&oa).Error; err != nil {
+		// 更新中にエラーが発生した場合のエラーハンドリング
+		responseMessage = "RESUBMIT ERROR"
+	}
+
+	//戻り値メッセージ
+	c.JSON(http.StatusOK, gin.H{"document": responseMessage})
+
+}

--- a/go/src/main/api/ResubmitDocument.go
+++ b/go/src/main/api/ResubmitDocument.go
@@ -53,7 +53,6 @@ func ResubmitDocument(c *gin.Context) {
 	//更新用構造体
 	oa := model.ResubmitDocument{
 		DocumentID:     request.DocumentID,
-		UserID:         request.UserID,
 		RequestAt:      request.RequestAt,
 		StartTime:      request.StartTime,
 		StartFlame:     request.StartFlame,

--- a/go/src/main/api/ResubmitDocument.go
+++ b/go/src/main/api/ResubmitDocument.go
@@ -63,7 +63,6 @@ func ResubmitDocument(c *gin.Context) {
 		Status:         1,
 		ReadFlag:       false,
 		StudentComment: request.StudentComment,
-		TeacherComment: request.TeacherComment,
 		DivisionID:     request.DivisionID,
 	}
 

--- a/go/src/main/main.go
+++ b/go/src/main/main.go
@@ -62,6 +62,8 @@ func main() {
 
 		routes.POST("/ra", api.RejectAuth)
 
+		routes.POST("/rsd", api.ResubmitDocument)
+
 		// 実装予定の管理者向けのAPI
 		// routes.POST("/cd", api.CreateDocument)
 		// routes.POST("/dd", api.DeleteDocument)

--- a/go/src/main/model/model.go
+++ b/go/src/main/model/model.go
@@ -121,6 +121,6 @@ type ResubmitDocument struct {
 	Status         int       `json:"status"`          //ステータス
 	ReadFlag       bool      `json:"read_flag"`       //既読フラグ
 	StudentComment string    `json:"student_comment"` // 学生コメント
-	TeacherComment string    `json:"teacher_comment"` //教員コメント
-	DivisionID     int       `json:"division_id"`     //区分ID
+	// TeacherComment string    `json:"teacher_comment"` //教員コメント
+	DivisionID int `json:"division_id"` //区分ID
 }

--- a/go/src/main/model/model.go
+++ b/go/src/main/model/model.go
@@ -105,13 +105,13 @@ type ResubmitDocumentRequest struct {
 	EndFlame       int       `json:"end_flame"`
 	Location       string    `json:"location"`
 	StudentComment string    `json:"student_comment"`
-	TeacherComment string    `json:"teacher_comment"`
-	DivisionID     int       `json:"division_id"`
+	// TeacherComment string    `json:"teacher_comment"`
+	DivisionID int `json:"division_id"`
 }
 
 type ResubmitDocument struct {
-	DocumentID     int       `json:"document_id"`     //書類ID
-	UserID         int       `json:"user_id"`         //ユーザID
+	DocumentID int `json:"document_id"` //書類ID
+	// UserID         int       `json:"user_id"`         //ユーザID
 	RequestAt      time.Time `json:"request_at"`      // 申請日
 	StartTime      time.Time `json:"start_time"`      // 欠席開始日
 	StartFlame     int       `json:"start_flame"`     //開始時限

--- a/go/src/main/model/model.go
+++ b/go/src/main/model/model.go
@@ -118,7 +118,7 @@ type ResubmitDocument struct {
 	EndTime        time.Time `json:"end_time"`        // 欠席終了日
 	EndFlame       int       `json:"end_flame"`       //終了時限
 	Location       string    `json:"location"`        // 場所
-	Status         *int      `json:"status"`          //ステータス
+	Status         int       `json:"status"`          //ステータス
 	ReadFlag       bool      `json:"read_flag"`       //既読フラグ
 	StudentComment string    `json:"student_comment"` // 学生コメント
 	TeacherComment string    `json:"teacher_comment"` //教員コメント

--- a/go/src/main/model/model.go
+++ b/go/src/main/model/model.go
@@ -93,3 +93,18 @@ type CreateDocumentRequest struct {
 type DeleteDocumentRequest struct {
 	DocumentID int `json:"document_id"`
 }
+
+//ResubmitDocumentで使用する構造体
+type ResubmitDocumentRequest struct {
+	DocumentID     int       `json:"document_id"`
+	UserID		   int		 `json:"user_id"`
+	RequestAt      time.Time `json:"request_at"`
+	StartTime      time.Time `json:"start_time"`
+	StartFlame     int       `json:"start_flame"`
+	EndTime        time.Time `json:"end_time"`
+	EndFlame       int       `json:"end_flame"`
+	Location       string    `json:"location"`
+	StudentComment string    `json:"student_comment"`
+	TeacherComment string    `json:"teacher_comment"`
+	DivisionID	   int 		 `json:"division_id"`
+}

--- a/go/src/main/model/model.go
+++ b/go/src/main/model/model.go
@@ -90,14 +90,14 @@ type CreateDocumentRequest struct {
 }
 
 // DeleteDocumentで使用する構造体
-type DeleteDocumentRequest struct {
-	DocumentID int `json:"document_id"`
-}
+// type DeleteDocumentRequest struct {
+// 	DocumentID int `json:"document_id"`
+// }
 
-//ResubmitDocumentで使用する構造体
+// ResubmitDocumentで使用する構造体
 type ResubmitDocumentRequest struct {
 	DocumentID     int       `json:"document_id"`
-	UserID		   int		 `json:"user_id"`
+	UserID         int       `json:"user_id"`
 	RequestAt      time.Time `json:"request_at"`
 	StartTime      time.Time `json:"start_time"`
 	StartFlame     int       `json:"start_flame"`
@@ -106,5 +106,21 @@ type ResubmitDocumentRequest struct {
 	Location       string    `json:"location"`
 	StudentComment string    `json:"student_comment"`
 	TeacherComment string    `json:"teacher_comment"`
-	DivisionID	   int 		 `json:"division_id"`
+	DivisionID     int       `json:"division_id"`
+}
+
+type ResubmitDocument struct {
+	DocumentID     int       `json:"document_id"`     //書類ID
+	UserID         int       `json:"user_id"`         //ユーザID
+	RequestAt      time.Time `json:"request_at"`      // 申請日
+	StartTime      time.Time `json:"start_time"`      // 欠席開始日
+	StartFlame     int       `json:"start_flame"`     //開始時限
+	EndTime        time.Time `json:"end_time"`        // 欠席終了日
+	EndFlame       int       `json:"end_flame"`       //終了時限
+	Location       string    `json:"location"`        // 場所
+	Status         *int      `json:"status"`          //ステータス
+	ReadFlag       bool      `json:"read_flag"`       //既読フラグ
+	StudentComment string    `json:"student_comment"` // 学生コメント
+	TeacherComment string    `json:"teacher_comment"` //教員コメント
+	DivisionID     int       `json:"division_id"`     //区分ID
 }


### PR DESCRIPTION
引数に再提出が必要な公欠届のデータを受け取って、既存の当該公欠届のデータを更新し、再び認可待ち状態にします